### PR TITLE
updates to google gpu test with new ubuntu 24.04 base

### DIFF
--- a/google/gpu/Dockerfile
+++ b/google/gpu/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   socat
 ADD Dockerfile.d/etc_udev_rules.d_90-flannel.rules /etc/udev/rules.d/90-flannel.rules
 ADD Dockerfile.d/u7s-entrypoint.sh /
-RUN apt-get install -y gnupg2 && apt-get update
+RUN apt-get install -y gnupg2 vim && apt-get update
 
 # If not set, is set to "void"
 ENV NVIDIA_VISIBLE_DEVICES=all
@@ -41,11 +41,9 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 RUN /bin/bash -c "curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list" && apt-get update && apt-get install -y nvidia-container-toolkit && nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml --device-name-strategy=uuid
+    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list" && apt-get update && apt-get install -y nvidia-container-toolkit && nvidia-ctk runtime configure --runtime=containerd
 
-# In practice I didn't need this either.
-# This is run in entrypoint
-# nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml --device-name-strategy=uuid && nvidia-ctk cdi list && nvidia-ctk config --in-place --set nvidia-container-runtime.mode=cdi && nvidia-ctk runtime configure --runtime=containerd --cdi.enabled && systemctl restart containerd
+# note we need to run make nvidia
 
 ENTRYPOINT ["/u7s-entrypoint.sh", "/usr/local/bin/entrypoint", "/sbin/init"]
 

--- a/google/gpu/Makefile
+++ b/google/gpu/Makefile
@@ -1,0 +1,165 @@
+# Run `make help` to show usage
+.DEFAULT_GOAL := help
+
+# Change ports for different kubernetes services
+export PORT_ETCD ?= 2379
+export PORT_KUBELET ?= 10250
+export PORT_FLANNEL ?= 8472
+export PORT_KUBE_APISERVER ?= 6443
+
+# HOSTNAME is the name of the physical host
+export HOSTNAME ?= $(shell hostname)
+# HOST_IP is the IP address of the physical host. Accessible from other hosts.
+export HOST_IP ?= $(shell ip --json route get 1 | jq -r .[0].prefsrc)
+# NODE_NAME is the host name of the Kubernetes node running in Rootless Docker.
+# Not accessible from other hosts.
+export NODE_NAME ?= u7s-$(HOSTNAME)
+# NODE_SUBNET is the subnet of the Kubernetes node running in Rootless Docker.
+# Not accessible from other hosts.
+export NODE_SUBNET ?= $(shell $(CURDIR)/Makefile.d/node-subnet.sh)
+# NODE_IP is the IP address of the Kubernetes node running in Rootless Docker.
+# Not accessible from other hosts.
+export NODE_IP := $(subst .0/24,.100,$(NODE_SUBNET))
+
+export CONTAINER_ENGINE ?= $(shell $(CURDIR)/Makefile.d/detect-container-engine.sh CONTAINER_ENGINE)
+
+export CONTAINER_ENGINE_TYPE ?= $(shell $(CURDIR)/Makefile.d/detect-container-engine.sh CONTAINER_ENGINE_TYPE)
+
+COMPOSE ?= $(shell $(CURDIR)/Makefile.d/detect-container-engine.sh COMPOSE)
+
+NODE_SERVICE_NAME := node
+NODE_SHELL := $(COMPOSE) exec \
+	-e HOST_IP=$(HOST_IP) \
+	-e NODE_NAME=$(NODE_NAME) \
+	-e NODE_SUBNET=$(NODE_SUBNET) \
+	-e NODE_IP=$(NODE_IP) \
+	-e PORT_KUBE_APISERVER=$(PORT_KUBE_APISERVER) \
+	-e PORT_FLANNEL=$(PORT_FLANNEL) \
+	-e PORT_KUBELET=$(PORT_KUBELET) \
+	-e PORT_ETCD=$(PORT_ETCD) \
+	$(NODE_SERVICE_NAME)
+
+ifeq ($(CONTAINER_ENGINE),nerdctl)
+ifneq (,$(wildcard $(XDG_RUNTIME_DIR)/bypass4netnsd.sock))
+	export BYPASS4NETNS := true
+	export BYPASS4NETNS_IGNORE_SUBNETS := ["10.96.0.0/16", "10.244.0.0/16", "$(NODE_SUBNET)"]
+endif
+endif
+
+.PHONY: help
+help:
+	@echo '# Bootstrap a cluster'
+	@echo 'make up'
+	@echo 'make kubeadm-init'
+	@echo 'make install-flannel'
+	@echo
+	@echo '# Enable kubectl'
+	@echo 'make kubeconfig'
+	@echo 'export KUBECONFIG=$$(pwd)/kubeconfig'
+	@echo 'kubectl get pods -A'
+	@echo
+	@echo '# Multi-host'
+	@echo 'make join-command'
+	@echo 'scp join-command another-host:~/usernetes'
+	@echo 'ssh another-host make -C ~/usernetes up kubeadm-join'
+	@echo 'make sync-external-ip'
+	@echo
+	@echo '# Debug'
+	@echo 'make logs'
+	@echo 'make shell'
+	@echo 'make kubeadm-reset'
+	@echo 'make down-v'
+	@echo 'kubectl taint nodes --all node-role.kubernetes.io/control-plane-'
+
+.PHONY: check-preflight
+check-preflight:
+	./Makefile.d/check-preflight.sh
+
+.PHONY: render
+render: check-preflight
+	$(COMPOSE) config
+
+.PHONY: up
+up: check-preflight
+	$(COMPOSE) up --build -d
+
+.PHONY: down
+down:
+	$(COMPOSE) down
+
+.PHONY: nvidia
+nvidia:
+	$(NODE_SHELL) nvidia-ctk system create-dev-char-symlinks --create-all
+	$(NODE_SHELL) nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml --device-name-strategy=uuid
+	$(NODE_SHELL) nvidia-ctk cdi list
+	$(NODE_SHELL) nvidia-ctk config --in-place --set nvidia-container-runtime.mode=cdi
+	$(NODE_SHELL) nvidia-ctk runtime configure --runtime=containerd --cdi.enabled --set-as-default
+	$(NODE_SHELL) sed -i '1s/.*/accept-nvidia-visible-devices-as-volume-mounts = true/' /etc/nvidia-container-runtime/config.toml
+	$(NODE_SHELL) sed -i '2s/^.//' /etc/nvidia-container-runtime/config.toml
+	$(NODE_SHELL) systemctl restart containerd
+	
+.PHONY: down-v
+down-v:
+	$(COMPOSE) down -v
+
+.PHONY: shell
+shell:
+	$(NODE_SHELL) bash
+
+.PHONY: logs
+logs:
+	$(NODE_SHELL) journalctl --follow --since="1 day ago"
+
+.PHONY: kubeconfig
+kubeconfig:
+	$(COMPOSE) exec -T $(NODE_SERVICE_NAME) sed -e "s/$(NODE_NAME)/127.0.0.1/g" /etc/kubernetes/admin.conf >kubeconfig
+	@echo "# Run the following command by yourself:"
+	@echo "export KUBECONFIG=$(shell pwd)/kubeconfig"
+ifeq ($(shell command -v kubectl 2> /dev/null),)
+	@echo "# To install kubectl, run the following command too:"
+	@echo "make kubectl"
+endif
+
+.PHONY: kubectl
+kubectl:
+	$(COMPOSE) exec -T --workdir=/usr/bin $(NODE_SERVICE_NAME) tar c kubectl | tar xv
+	@echo "# Run the following command by yourself:"
+	@echo "export PATH=$(shell pwd):\$$PATH"
+	@echo "source <(kubectl completion bash)"
+
+.PHONY: join-command
+join-command:
+	echo "#!/bin/bash" >join-command
+	echo "set -eux -o pipefail" >>join-command
+	echo "echo \"$(HOST_IP)  $(NODE_NAME)\" >/etc/hosts.u7s" >>join-command
+	echo "cat /etc/hosts.u7s >>/etc/hosts" >>join-command
+	$(NODE_SHELL) kubeadm token create --print-join-command | tr -d '\r' >>join-command
+	@echo "# Copy the 'join-command' file to another host, and run the following commands:"
+	@echo "# On the other host (the new worker):"
+	@echo "#   make kubeadm-join"
+	@echo "# On this host (the control plane):"
+	@echo "#   make sync-external-ip"
+
+.PHONY: kubeadm-init
+kubeadm-init:
+	$(NODE_SHELL) sh -euc "envsubst </usernetes/kubeadm-config.yaml >/tmp/kubeadm-config.yaml"
+	$(NODE_SHELL) kubeadm init --config /tmp/kubeadm-config.yaml --skip-token-print
+	$(MAKE) sync-external-ip
+	@echo "# Run 'make join-command' to print the join command"
+
+.PHONY: sync-external-ip
+sync-external-ip:
+	$(NODE_SHELL) /usernetes/Makefile.d/sync-external-ip.sh
+
+.PHONY: kubeadm-join
+kubeadm-join:
+	$(NODE_SHELL) /bin/bash /usernetes/join-command
+	@echo "# Run 'make sync-external-ip' on the control plane"
+
+.PHONY: kubeadm-reset
+kubeadm-reset:
+	$(NODE_SHELL) kubeadm reset --force
+
+.PHONY: install-flannel
+install-flannel:
+	$(NODE_SHELL) /usernetes/Makefile.d/install-flannel.sh

--- a/google/gpu/docker-compose.yaml
+++ b/google/gpu/docker-compose.yaml
@@ -11,13 +11,15 @@ services:
     networks:
       default:
         ipv4_address: ${NODE_IP}
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all # or number of GPUs
-              capabilities: [gpu]
+    devices:
+      - nvidia.com/gpu
+    # deploy:
+    #  resources:
+    #    reservations:
+    #      devices:
+    #        - driver: nvidia
+    #          count: all # or number of GPUs
+    #          capabilities: [gpu]
     ports:
       # <host>:<container>
       # etcd (default: 2379)

--- a/google/gpu/nvidia-device-plugin.yaml
+++ b/google/gpu/nvidia-device-plugin.yaml
@@ -39,18 +39,21 @@ spec:
       priorityClassName: "system-node-critical"
       containers:
       - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
-        args:
-         # Defaulting to auto won't find devices
-         - "--device-discovery-strategy=tegra"
         name: nvidia-device-plugin-ctr
+        # This should not be needed with cdi
+        # args:
+        #   - "--device-discovery-strategy=tegra"
         env:
           - name: FAIL_ON_INIT_ERROR
             value: "false"
-# Note that it worked without these
-#        securityContext:
-#          privileged: true
-#          capabilities:
-#            add: ["ALL"]
+          - name: CUDA_VISIBLE_DEVICES
+            value: all
+        # testing / debugging
+        # command: ["sleep", "infinity"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         volumeMounts:
         - name: device-plugin
           mountPath: /var/lib/kubelet/device-plugins

--- a/google/gpu/tf/basic.tfvars
+++ b/google/gpu/tf/basic.tfvars
@@ -1,4 +1,4 @@
-compute_family = "usernetes-gpu"
+compute_family = "usernetes-gpu-ubuntu"
 compute_node_specs = [
   {
     name_prefix  = "flux"
@@ -18,7 +18,6 @@ sudo modprobe iptable_nat
 
 sudo rm -rf /etc/cdi/nvidia.yaml
 sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml --device-name-strategy=uuid
-sudo systemctl restart docker.service docker.socket
 systemctl --user restart docker.service
 
 mkdir -p /var/nfs/home || true


### PR DESCRIPTION
This setup is working. Changes:

- I created a base from scratch with newer CUDA (I think 12.8) which seemed to work with the V100
- We need to install `nvidia-ctk` and generate CDI on the host at VM startup (via terraform)
- Since we can do this, we don't have to remove old docker / software from the system and reinstall (bug prone)
- I tried to avoid using the gpu operator because it almost always destroyed the setup
- The nvidia runtime needs to be used with devices for the gpu in the docker-compose to get `nvidia-smi` and devices seen in the docker container for `make shell`
- If we use the nvidia device plugin without CDI, it doesn't detect anything. If we just use the previous strategy with tegra and cdi, it will error when we create the pods because it doesn't know what tegra is. The solution was to do more configuring in the `make shell` with the `nvidia-ctk` to ensure the cdi specs were correct for the GPU. I added this as a new command to the Makefile for `make nvidia`

The above setup worked and reproduced. 